### PR TITLE
Correct typo in README documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,6 @@ manifest (west.yml).
 Documentation
 *************
 
-Official latest documentation at https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html
+Offi cial latest documentation at https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html
 
 For earlier versions, open the latest version and use the drop-down under the title header.


### PR DESCRIPTION
Fix typo in documentation link section.